### PR TITLE
feat: Script para autenticar o CNPJ da empresa

### DIFF
--- a/app/utils/auth_cnpj.py
+++ b/app/utils/auth_cnpj.py
@@ -1,0 +1,16 @@
+import requests
+import json 
+
+def consulta_cnpj(cnpj):
+
+    url = f"https://receitaws.com.br/v1/cnpj/{cnpj}"
+    querystring = {"token":"XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX","cnpj":"06990590000123","plugin":"RF"}
+
+    response = requests.request("GET", url, params=querystring)
+
+    resp = json.loads(response.text)
+
+    print(resp['situacao'])
+
+# exemplo consulta_cnpj('33291488000102')
+     


### PR DESCRIPTION
Script responsável por fazer a autenticação de CNPJ's inseridos no momento do cadastro do vendedor, utilizando a API da Receita Federal de forma gratuita, onde poderemos realizar apenas 3 verificações por minuto.  